### PR TITLE
AMD branch's setup.sh script fixed to work from any directory

### DIFF
--- a/util/setup.sh
+++ b/util/setup.sh
@@ -2,14 +2,20 @@
 
 set -e
 
-OUTDIR="../src/js"
+PWD=$(pwd)
+UTILDIR="$PWD/$(dirname $0)"
+ROOT=${UTILDIR/\/util/}
+OUTDIR="$ROOT/src/js"
 VERSION="1.6.0"
 RJSVERSION="0.23.0"
 
 DOJODIR="dojo-release-${VERSION}-src"
 REQUIREJSDIR="requirejs-${RJSVERSION}"
 
-OUTDIR=$(cd "$OUTDIR" &> /dev/null && pwd || echo "")
+if [ ! -d "$OUTDIR" ]; then
+    echo "Output directory is missing: $OUTDIR"
+    exit 1
+fi
 
 if [ -x $(which wget) ]; then
 	GET="wget --no-check-certificate -O -"
@@ -17,11 +23,6 @@ elif [ -x $(which curl) ]; then
 	GET="curl -L --insecure -o -"
 else
 	echo "No cURL, no wget, no downloads :("
-	exit 1
-fi
-
-if [ "$OUTDIR" = "" ]; then
-	echo "Output directory not found"
 	exit 1
 fi
 


### PR DESCRIPTION
Hola rmurphey!

I was having some trouble running the `util/setup.sh` script from the root of the project, it looks like it was assuming that you would always be running the script from the `util/` directory. I have made a little change which should now make it so that you can run the script from any directory. What it does is parse out where the `util/` directory lives based on how you called the script, and then drops one directory so that we know the root directory of the project. Once that is known, finding the proper `$OUTDIR` is simple.

Also, I changed the check to make sure that the `$OUTDIR` exists so that it is in the same style as the rest of the directory checks in this script.

I think these changes make the script a little easier to work with, now and in the future, but of course if you feel otherwise no one is forcing you to accept my pull request :)

Take it easy,

Nick
