### PR TITLE
Added complete support for dojo 1.6.1

### DIFF
--- a/www/css/app.css
+++ b/www/css/app.css
@@ -4,5 +4,5 @@ widgets, you will probably want to include the two files below;
 otherwise, you can remove them.
 */
 
-@import '../js/dojo-release-1.6.0-src/dojo/resources/dojo.css';
-@import '../js/dojo-release-1.6.0-src/dijit/themes/claro/claro.css';
+@import '../js/dojo-release-1.6.1-src/dojo/resources/dojo.css';
+@import '../js/dojo-release-1.6.1-src/dijit/themes/claro/claro.css';

--- a/www/index.html
+++ b/www/index.html
@@ -15,7 +15,7 @@
     }
   } : {};
   </script>
-  <script src="js/dojo-release-1.6.0-src/dojo/dojo.js"></script>
+  <script src="js/dojo-release-1.6.1-src/dojo/dojo.js"></script>
   <script>dojo.require("app.base");</script>
 </body>
 </html>


### PR DESCRIPTION
Updated all paths in index, css, etc for dojo 1.6.1
Modified the build script for 1.6.1.
Added sed command to update the paths in the CSS file (app.css)
modified the way DISTDIR is created so it can be used in the releaseDir
param rather than using relative paths that might be different on
different setups
