### PR TITLE
Add LESS support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "src/js/util"]
 	path = src/js/util
 	url = https://github.com/dojo/util.git
+[submodule "src/js/less"]
+	path = src/js/less
+	url = https://github.com/cloudhead/less.js.git

--- a/src/index.html
+++ b/src/index.html
@@ -5,9 +5,12 @@
     <title>Dojo Boilerplate</title>
     <!-- Application-specific CSS should be stored in your application's package to ensure portability and to allow
          the build system to combine & minify it. -->
-    <link rel="stylesheet" href="js/app/resources/app.css">
+    <link rel="stylesheet/less" href="js/app/resources/app.less">
 </head>
 <body class="claro">
+    <!-- Inclusion of LESS. The following two lines will be removed in production. -->
+    <script>var less = { env: "development" };</script>
+    <script src="js/less/dist/less-1.1.5.min.js" defer></script>
     <!-- dojo.js is an AMD-compliant loader script. It accepts configuration either from a data-dojo-config attribute,
          as shown here, from a global dojoConfig object (which must be defined *before* dojo.js is loaded), or from
          a global require object.

--- a/src/js/app/resources/app.less
+++ b/src/js/app/resources/app.less
@@ -4,5 +4,7 @@
  * @imported CSS files into a single file.
  */
 
-@import '../../dojo/resources/dojo.css';
-@import '../../dijit/themes/claro/claro.css';
+@import url('../../dojo/resources/dojo.css');
+@import url('../../dijit/themes/claro/claro.css');
+
+@import '../../dijit/themes/claro/variables';

--- a/util/build.sh
+++ b/util/build.sh
@@ -38,6 +38,14 @@ else
     exit 1
 fi
 
+# build LESS file
+if which node >/dev/null; then
+    cd "$DISTDIR/js/app/resources"
+    node "$SRCDIR/js/less/bin/lessc" -x app.less > app.css
+    rm app.less
+fi
+
+
 cd "$UTILDIR"
 
 # copy the config.js file
@@ -46,6 +54,12 @@ cp "$SRCDIR/js/boot.js" "$DISTDIR/js/boot.js"
 # copy the index.html and make it production-friendly
 cp "$SRCDIR/index.html" "$DISTDIR/index.html"
 
-sed -i "s/, *isDebug: *1//" "$DISTDIR/index.html"
+# remove development lines in index.html and
+# translate *.less links to *.css
+sed -i "s/, *isDebug: *1//
+/^\s*<!--\s*Inclusion of LESS\..*$/d
+/^\s*<script>var less\s*=\s*.*<\/script>/d
+/^\s*<script src=[\"']js\/less\/dist\/less\(.*\)\.js[\"'][^>]*><\/script>/d
+s/\(<link\).*\(rel=\"stylesheet\)\/less\(\"\).*\(href=\"[^.]*\.\)less\(\">\)/\1 \2\3 \4css\5/" "$DISTDIR/index.html"
 
 echo "Build complete"


### PR DESCRIPTION
I've added support for developing stylesheets in LESS. I've also included Claro's `variables.less` for easy theming. During development, stylesheets are parsed client-side; the build process compiles the LESS to CSS and then strips the relevant lines from `index.html` and converts the inclusion of `app.less` to `app.css`.
