### PR TITLE
Used #!/usr/bin/env bash instead for greater compatibility 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
the previous #!/bin/bash doesn't work on some operating systems who put bash naturally in /usr/bin instead. 'env' is a way to locate the argument, in this case 'bash', and execute from the proper path environment variable.
