### PR TITLE
Fix copyOnly function - currently nothing gets marked copyOnly

### DIFF
--- a/src/app/package.js
+++ b/src/app/package.js
@@ -21,7 +21,7 @@ var profile = {
 		// are typically binaries (images, etc.) and may be corrupted by the build system if it attempts to process
 		// them and naively assumes they are scripts.
 		copyOnly: function (filename, mid) {
-			return (/^app\/resources\//.test(filename) && !/\.css$/.test(filename));
+			return (/^app\/resources\//.test(mid) && !/\.css$/.test(filename));
 		},
 
 		// Files that are AMD modules.


### PR DESCRIPTION
This copyOnly test should have been done on mid, not filename. 

If you use filename, the regex does not match correctly, as the filename never starts with "app"
