### PR TITLE
Check for 'dist' directory to keep build.sh from doing very bad things.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,11 @@ if [ ! -d "$TOOLSDIR" ]; then
 	exit 1
 fi
 
+if [ ! -d "$DISTDIR" ]; then
+    echo "No 'dist' directory! Please create one and rerun this script."
+    exit 1
+fi
+
 echo "Building application with $PROFILE to $DISTDIR."
 
 echo -n "Cleaning old files..."


### PR DESCRIPTION
I ran this script on a project that didn't have a 'dist' directory and it deleted my entire project! So I added a check to make sure that doesn't happen again.
